### PR TITLE
Proper behaviour for ctrl + backspace

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -454,6 +454,7 @@ static Key key[] = {
   { XK_Delete,        XK_ANY_MOD,     "\033[3~",      +1,    0},
   { XK_BackSpace,     XK_NO_MOD,      "\177",          0,    0},
   { XK_BackSpace,     Mod1Mask,       "\033\177",      0,    0},
+  { XK_BackSpace,     ControlMask,    "\033[127;5u",   0,    0 },
   { XK_Home,          ShiftMask,      "\033[2J",       0,   -1},
   { XK_Home,          ShiftMask,      "\033[1;2H",     0,   +1},
   { XK_Home,          XK_ANY_MOD,     "\033[H",        0,   -1},


### PR DESCRIPTION
After the fish update 4.x, the keybind for deleting a word changed from `alt-backspace` to `ctrl-backspace`. But pressing ctrl+backspace does not delete a word. This patch ensures the proper behaviour for `ctrl+backspace` which deletes word in the fish shell.

Refer to this: https://github.com/fish-shell/fish-shell/issues/10926